### PR TITLE
Update jpype version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 redis==3.2.1
 requests==2.24
-jpype1==1.0.1
+jpype1==1.2.0
 jellyfish==0.6.1
 click==7.0
 python-dotenv==0.14.0


### PR DESCRIPTION
As mentioned on spdx-online-tools python3 PR - https://github.com/spdx/spdx-online-tools/pull/205#discussion_r540369241 - jpype<1.2 has memory leakage issue.