### PR TITLE
Support a new schema of spdx.org/licenses

### DIFF
--- a/spdx_license_matcher/build_licenses.py
+++ b/spdx_license_matcher/build_licenses.py
@@ -33,7 +33,7 @@ def build_spdx_licenses():
     response = requests.get(url)
     licensesJson = response.json()
     licenses = licensesJson['licenses']
-    licensesUrl = [urljoin(url, license.get('detailsUrl')) for license in licenses]
+    licensesUrl = [urljoin(url, license.get('reference')) for license in licenses]
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         responses = list(pool.map(get_url, licensesUrl))

--- a/spdx_license_matcher/build_licenses.py
+++ b/spdx_license_matcher/build_licenses.py
@@ -4,6 +4,7 @@ import redis
 import requests
 from dotenv import load_dotenv
 import os
+from urllib.parse import urljoin
 
 from spdx_license_matcher.normalize import normalize
 from spdx_license_matcher.utils import compressStringToBytes
@@ -32,7 +33,7 @@ def build_spdx_licenses():
     response = requests.get(url)
     licensesJson = response.json()
     licenses = licensesJson['licenses']
-    licensesUrl = [license.get('detailsUrl') for license in licenses]
+    licensesUrl = [urljoin(url, license.get('detailsUrl')) for license in licenses]
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         responses = list(pool.map(get_url, licensesUrl))


### PR DESCRIPTION
It seems https://spdx.org/licenses/licenses.json returns relative urls and the field for json is `reference`, not `detailsUrl`.

This is an error I got, and this PR is a fix for the error.
```
Building SPDX License List. This may take a while...
Traceback (most recent call last):
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx_license_matcher/matcher.py", line 59, in <module>
    matcher()
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx_license_matcher/matcher.py", line 32, in matcher
    build_spdx_licenses()
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx_license_matcher/build_licenses.py", line 38, in build_spdx_licenses
    responses = list(pool.map(get_url, licensesUrl))
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/concurrent/futures/_base.py", line 598, in result_iterator
    yield fs.pop().result()
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/concurrent/futures/_base.py", line 435, in result
    return self.__get_result()
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/Users/mikit/.pyenv/versions/3.7.6/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx_license_matcher/build_licenses.py", line 20, in get_url
    res = requests.get(url, headers=headers)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/sessions.py", line 516, in request
    prep = self.prepare_request(req)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/sessions.py", line 459, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/models.py", line 314, in prepare
    self.prepare_url(url, params)
  File "/Users/mikit/Downloads/spdx-license-matcher/spdx-matcher/lib/python3.7/site-packages/requests/models.py", line 388, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL './AFL-2.0.html': No schema supplied. Perhaps you meant http://./AFL-2.0.html?
```