### PR TITLE
Fix package name for LicenseCompareHelper

### DIFF
--- a/spdx_license_matcher/utils.py
+++ b/spdx_license_matcher/utils.py
@@ -113,7 +113,7 @@ def checkTextStandardLicense(license, compareText):
 
     # Attach a Thread and start processing the request
     jpype.attachThreadToJVM()
-    package = jpype.JPackage("org.spdx.tools.compare")
+    package = jpype.JPackage("org.spdx.utility.compare")
     compareclass = package.LicenseCompareHelper
     try:
 


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>