### PR TITLE
Catch attribute error when decoding license key

### DIFF
--- a/spdx_license_matcher/computation.py
+++ b/spdx_license_matcher/computation.py
@@ -20,7 +20,7 @@ def get_close_matches(inputText, licenseData, threshold=0.9):
         try:
             licenseName = key.decode('utf-8')
             normalizedLicenseText = decompressBytesToString(licenseData.get(key))
-        except IOError:
+        except:
             licenseName = key
             normalizedLicenseText = normalize(licenseData.get(key))
         score = get_dice_coefficient(normalizedInputText, normalizedLicenseText)


### PR DESCRIPTION
This resolves an issue if the license key returned is a string
which is already decoded.  This throws a missing attribute
exception.  Since the except block already retries without the
decode, removing the IOEerror exception resolves the issue.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>