### PR TITLE
Update repo owner in git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ found to be a close match.
 Ensure that you are using Python3 for installation of the tool.
 
 * Clone the repository
-    * `git clone https://github.com/Ugtan/spdx-license-match-tool.git`
+    * `git clone https://github.com/spdx/spdx-license-match-tool.git`
 
 * Make a Python3 virtual environment
     * `python3 -m venv <name-of-the-virtual-env>`


### PR DESCRIPTION
(it appears) this repo has been transferred from `Ugtan` to `spdx`. While the clone on the old url still works, it would be better to change it to the new repo owner to prevent confusion (and also conflicts, should @Ugtan create another `spdx-license-matcher` repo).