### PR TITLE
Update Redis installation + fix README format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,129 @@
-# SPDX License Match Tool
-A python tool which takes the license text from the user, compares it with the SPDX license list
-using an algorithm which finds close matches and returns differences if the input license text is
-found to be a close match.
+# SPDX License Matcher
 
-## Installation
-Ensure that you are using Python3 for installation of the tool.
+A Python tool which takes the license text from the user,
+compares it with the [SPDX License List][spdx-license-list]
+using an algorithm which finds close matches and returns differences
+if the input license text is found to be a close match.
 
-* Clone the repository
-    * `git clone https://github.com/spdx/spdx-license-matcher.git`
-
-* Make a Python3 virtual environment
-    * `cd spdx-license-matcher`
-    * `python3 -m venv <name-of-the-virtual-env>`
-
-* Activate the venv
-    * `source <name-of-the-virtual-env>/bin/activate`
-
-* Install spdx-license-matcher with required dependencies inside virtual environment
-    * `pip install .`
-    
-* Install redis server on your local machine.
-
-        **For linux users**
-        
-        * Use the command `sudo apt-get install redis-server` to install the redis server.
-
-        **For Mac users**
-
-        * Install the redis by running the command
-
-            `brew install redis`.
-        * If you want to run redis whenever your computer starts then run
-
-            `ln -sfv /usr/local/opt/redis/*.plist ~/Library/LaunchAgents`.
-
-        * To run the redis server use
-
-            `launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist`.
-        * To test if the redis is working run the command `redis-cli ping`. If it returns `Pong` then you are good to go.
-
-        **For Windows users**
-
-        * Download the redis server from [here](https://github.com/microsoftarchive/redis/releases) and install it.
-    * Make sure redis server is running and keep it running until you are done using the tool.
-
-        *The redis is used to store the license text of license present on the SPDX license list. For the very first time it may take a while to build the license on the redis server.*
-
-        *SPDX License Matcher matches the license text input by the user(via license submittal form) against the data present on the redis to find for duplicate and near matches.*
-
+A Redis server is used to store the license texts.
 
 ## Usage
-To run the tool just use the command `spdx-license-matcher -f <file-name> -t <threshold>`.
-* `filename` is the file with the license text(if you don't provide the file as well then it will prompt you to add it).
-* `threshold` is a value upto which we will just won't consider a match.(optional)
 
-You can also run `spdx-license-matcher --help` for more info.
+```shell
+spdx-license-matcher -f filename -t threshold
+```
 
+- `filename` is the file with the license text
+  (if not provided, it will prompt you to add it).
+- `threshold` is a value up to which we will just won't consider a match.
+  (optional)
+
+Run `spdx-license-matcher --help` for more info.
+
+## Installation
+
+Ensure that you are using Python 3 for installation of the tool.
+
+1. Clone the repository
+
+    ```shell
+    git clone https://github.com/spdx/spdx-license-matcher.git
+    ```
+
+2. Make a Python3 virtual environment
+
+    ```shell
+    cd spdx-license-matcher
+    python3 -m venv virtual-env-name
+    ```
+
+3. Activate the virtual environment
+
+    ```shell
+    source virtual-env-name/bin/activate
+    ```
+
+4. Install spdx-license-matcher with required dependencies inside
+   the virtual environment
+
+   ```shell
+   pip install .
+   ```
+
+5. Install Redis (or Valkey) server on your local machine
+
+    - Linux
+
+      ```shell
+      sudo apt-get install redis-server
+      ```
+
+    - macOS
+
+      ```shell
+      brew install redis
+      ```
+
+      To run the Redis whenever your computer starts:
+
+      ```shell
+      brew services start redis
+      ```
+
+      To run the Redis server:
+
+      ```shell
+      redis-server /opt/homebrew/etc/redis.conf
+      ```
+
+      To test if the Redis is working:
+
+      ```shell
+      redis-cli ping
+      ```
+
+      If it returns `PONG` then you are good to go.
+
+    - Windows
+
+      Download the Redis server from
+      <https://github.com/microsoftarchive/redis/releases> and install it.
+
+- Make sure the Redis/Valkey server is running
+  and keep it running until you are done using the tool.
+  - For the very first time it may take a while to build the license.
+  - `SPDX_REDIS_HOST` environment variable can be set to the location of your
+    Redis/Valkey server (default is `localhost`). The port is `6379`.
 
 ## Workflow
+
 The workflow of the tool is as follows:
-* Reads the license text as input from the user.
-* Build a redis database with all the license text present on the SPDX license list.
-* Compare the license text with the license text present in the database.
-    * Normalises the license text based on the SPDX Matching guidelines while ignore the replaceable text
+
+- Reads the license text as input from the user.
+- Build a Redis/Valkey database with all the license text present on the
+  SPDX License List.
+- Compare the license text with the license text present in the database.
+  - Normalizes the license text based on the SPDX Matching guidelines while
+    ignore the replaceable text
     and only focusing on substantial text for matching purposes.
-    * Tokenizes normalised text into a list of bigrams. This is necessary for the token based algorithm we are using for our use case.
-    * Use a token based similarity metric algorithm namely [Sorensen dice algorithm](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient) which is based on the logic to find the common tokens, and divide it by the total number of tokens present by combining both of the sets. This algorithm helps us to distinguish our close matches.
-    * A threshold value is used where we just won't consider a match.
-    * If the match is 100% then we say its a perfect match.
-    * If the match is between a threshold value and 100% then we apply the full matching algorithms and compares the closely matched license text to the license text of SPDX Standard License using a [method](https://github.com/spdx/tools/blob/b61e655ad997d7669faab65cff7d0b36da03cab5/src/org/spdx/compare/LicenseCompareHelper.java#L568) present in the SPDX tools. 
-        * If there is a match then the given license text matches with the SPDX standard license.
-        * If there is no match then we simply display the differences of the given license text with that of SPDX license list.
+  - Tokenizes the normalized text into a list of bigrams. This is necessary
+    for the token-based algorithm we are using for our use case.
+  - Use a token based similarity metric algorithm namely
+    [Sørensen-Dice algorithm][sorensen-dice] which is based on the logic
+    to find the common tokens, and divide it by the total number of tokens
+    present by combining both of the sets.
+    This algorithm helps us to distinguish our close matches.
+  - A threshold value is used where we just won't consider a match.
+  - If the match is 100% then we say it's a perfect match.
+  - If the match is between a threshold value and 100% then we apply the
+    full matching algorithms and compares the closely matched license text to
+    the license text of SPDX Standard License using a [method][method] present
+    in the SPDX tools.
+    - If there is a match then the given license text matches with the SPDX
+      standard license.
+    - If there is no match then we simply display the differences of the given
+      license text with that of SPDX License List.
+
+[spdx-license-list]: https://spdx.org/licenses/
+[sorensen-dice]: https://en.wikipedia.org/wiki/Dice-S%C3%B8rensen_coefficient
+[method]: https://github.com/spdx/tools/blob/1f4f85ad3fdb63577f9e4db4ccce0c7f894e2f04/src/org/spdx/compare/LicenseCompareHelper.java#L592

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Ensure that you are using Python 3 for installation of the tool.
     ```
 
 4. Install spdx-license-matcher with required dependencies inside
-   the virtual environment
+    the virtual environment
 
-   ```shell
-   pip install .
-   ```
+    ```shell
+    pip install .
+    ```
 
 5. Install Redis (or Valkey) server on your local machine
 
@@ -64,19 +64,27 @@ Ensure that you are using Python 3 for installation of the tool.
       brew install redis
       ```
 
-      To run the Redis whenever your computer starts:
-
-      ```shell
-      brew services start redis
-      ```
-
       To run the Redis server:
 
       ```shell
       redis-server /opt/homebrew/etc/redis.conf
       ```
 
-      To test if the Redis is working:
+      To run the Redis whenever your computer starts:
+
+      ```shell
+      brew services start redis
+      ```
+
+    - Windows
+
+      Download the Redis server from
+      <https://github.com/microsoftarchive/redis/releases> and install it.
+
+    Make sure the Redis/Valkey server is running
+    and keep it running until you are done using the tool.
+
+    - To test if the Redis is working:
 
       ```shell
       redis-cli ping
@@ -84,45 +92,39 @@ Ensure that you are using Python 3 for installation of the tool.
 
       If it returns `PONG` then you are good to go.
 
-    - Windows
-
-      Download the Redis server from
-      <https://github.com/microsoftarchive/redis/releases> and install it.
-
-- Make sure the Redis/Valkey server is running
-  and keep it running until you are done using the tool.
-  - For the very first time it may take a while to build the license.
-  - `SPDX_REDIS_HOST` environment variable can be set to the location of your
-    Redis/Valkey server (default is `localhost`). The port is `6379`.
+    - For the very first time it may take a while to build the license.
+    - `SPDX_REDIS_HOST` environment variable can be set to the location of
+      your Redis/Valkey server (default is `localhost`). The port is `6379`.
 
 ## Workflow
 
 The workflow of the tool is as follows:
 
-- Reads the license text as input from the user.
-- Build a Redis/Valkey database with all the license text present on the
-  SPDX License List.
-- Compare the license text with the license text present in the database.
-  - Normalizes the license text based on the SPDX Matching guidelines while
-    ignore the replaceable text
-    and only focusing on substantial text for matching purposes.
-  - Tokenizes the normalized text into a list of bigrams. This is necessary
-    for the token-based algorithm we are using for our use case.
-  - Use a token based similarity metric algorithm namely
-    [Sørensen-Dice algorithm][sorensen-dice] which is based on the logic
-    to find the common tokens, and divide it by the total number of tokens
-    present by combining both of the sets.
-    This algorithm helps us to distinguish our close matches.
-  - A threshold value is used where we just won't consider a match.
-  - If the match is 100% then we say it's a perfect match.
-  - If the match is between a threshold value and 100% then we apply the
-    full matching algorithms and compares the closely matched license text to
-    the license text of SPDX Standard License using a [method][method] present
-    in the SPDX tools.
-    - If there is a match then the given license text matches with the SPDX
-      standard license.
-    - If there is no match then we simply display the differences of the given
-      license text with that of SPDX License List.
+1. Reads the license text as input from the user.
+2. Build a Redis/Valkey database with all the license text present on the
+    SPDX License List.
+3. Compare the license text with the license text present in the database.
+
+    - Normalizes the license text based on the SPDX Matching guidelines while
+      ignore the replaceable text
+      and only focusing on substantial text for matching purposes.
+    - Tokenizes the normalized text into a list of bigrams. This is necessary
+      for the token-based algorithm we are using for our use case.
+    - Use a token based similarity metric algorithm namely
+      [Sørensen-Dice algorithm][sorensen-dice] which is based on the logic
+      to find the common tokens, and divide it by the total number of tokens
+      present by combining both of the sets.
+      This algorithm helps us to distinguish our close matches.
+    - A threshold value is used where we just won't consider a match.
+    - If the match is 100% then we say it's a perfect match.
+    - If the match is between a threshold value and 100% then we apply the
+      full matching algorithms and compares the closely matched license text
+      to the license text of SPDX Standard License using a [method][method]
+      present in the SPDX tools.
+      - If there is a match then the given license text matches with the SPDX
+        standard license.
+      - If there is no match then we simply display the differences of the given
+        license text with that of SPDX License List.
 
 [spdx-license-list]: https://spdx.org/licenses/
 [sorensen-dice]: https://en.wikipedia.org/wiki/Dice-S%C3%B8rensen_coefficient

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ spdx-license-matcher -f filename -t threshold
 ```
 
 - `filename` is the file with the license text
-  (if not provided, it will prompt you to add it).
-- `threshold` is a value up to which we will just won't consider a match.
+  (required)
+- `threshold` is a value up to which we will just won't consider a match
   (optional)
 
 Run `spdx-license-matcher --help` for more info.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The workflow of the tool is as follows:
       - If there is no match then we simply display the differences of the given
         license text with that of SPDX License List.
 
+## History
+
+- This project started as [a Google Summer of Code 2019 project][gsoc2019],
+  with contribution from [@ugtan][].
+- Now maintained by the SPDX community and updated for Python 3.
+- See SPDX's participation in Google Summer of Code (GSoC):
+  <https://github.com/spdx/GSoC>.
+
 [spdx-license-list]: https://spdx.org/licenses/
 [sorensen-dice]: https://en.wikipedia.org/wiki/Dice-S%C3%B8rensen_coefficient
 [method]: https://github.com/spdx/tools/blob/1f4f85ad3fdb63577f9e4db4ccce0c7f894e2f04/src/org/spdx/compare/LicenseCompareHelper.java#L592
+[gsoc2019]: https://summerofcode.withgoogle.com/archive/2019/projects/5687492043341824
+[@ugtan]: https://github.com/ugtan

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ spdx-license-matcher -f filename -t threshold
 - `filename` is the file with the license text
   (required)
 - `threshold` is a value up to which we will just won't consider a match
-  (optional)
+  (optional; default: 0.9)
 
 Run `spdx-license-matcher --help` for more info.
 


### PR DESCRIPTION
- Fix Markdown formatting issues of Redis installation section
- Update macOS Redis installation instructions, use modern brew commands
- Move `redis-cli ping` command from macOS to common section as it is used by all OSes
- Remove redundant information about matching in Redis
- Use code block Markdown format to allow user to copy and paste commands easier
- Add a history section